### PR TITLE
Fix call to scheme size function

### DIFF
--- a/scheme/j-bob-lang.scm
+++ b/scheme/j-bob-lang.scm
@@ -35,4 +35,4 @@
 (defun size (x)
   (if (atom x)
     '0
-    (+ '1 (size (car x)) (size (cdr x)))))
+    (+ '1 (+ (size (car x)) (size (cdr x))))))


### PR DESCRIPTION
The `+` function is defined to operate on two arguments, but the `size` function calls it with three. This commit updates `size` to use nested calls to `+` with two arguments each.
