### PR TITLE
Remove measure declarations from rewrite/define+

### DIFF
--- a/acl2/j-bob.lisp
+++ b/acl2/j-bob.lisp
@@ -756,7 +756,6 @@
     defs))
 
 (defun rewrite/define+1 (defs1 defs2 pfs)
-  (declare (xargs :measure (size pfs)))
   (if (equal defs1 defs2)
     defs1
     (if (atom pfs)
@@ -769,7 +768,6 @@
         (cdr pfs)))))
 
 (defun rewrite/define+ (defs pfs)
-  (declare (xargs :measure (size pfs)))
   (if (atom pfs)
     defs
     (rewrite/define+1 defs


### PR DESCRIPTION
This change was necessary to avoid the following error--at least using
ACL2 versions 7.0 and 8.0 which were the only ones tried.

  ACL2 Error in ( DEFUN REWRITE/DEFINE+ ...):  It is illegal to supply
  a measure for a non-recursive function, as has been done for REWRITE/DEFINE+.
  To avoid this error, see :DOC set-bogus-measure-ok.