### PR TITLE
Fix error about :measure for non-recursive function.

### DIFF
--- a/acl2/j-bob.lisp
+++ b/acl2/j-bob.lisp
@@ -769,7 +769,6 @@
         (cdr pfs)))))
 
 (defun rewrite/define+ (defs pfs)
-  (declare (xargs :measure (size pfs)))
   (if (atom pfs)
     defs
     (rewrite/define+1 defs


### PR DESCRIPTION
I suspect this patch would not cause problems in any recent version of ACL2 (the function in question is just not recursive, so it shouldn't have a :measure).